### PR TITLE
Add StructEval YAML benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ president:
 - [**Learn YAML in Y Minutes**](https://learnxinyminutes.com/docs/yaml), Learn X in Y minutes series, 
 - [**Deep dive into TOML, JSON and YAML**](https://gohugohq.com/howto/toml-json-yaml-comparison/),  Go Hugo HQ, Dec 2016
 - [**YAML @ Wikipedia**](https://en.wikipedia.org/wiki/YAML)
+- [**StructEval: Benchmarking LLMs' Capabilities to Generate Structural Outputs**](https://arxiv.org/abs/2505.20139) - TMLR 2025 benchmark evaluating YAML generation and conversion with syntax and structural checks, alongside 17 other formats. ([code](https://github.com/TIGER-AI-Lab/StructEval))
 
 
 ## Tips & Gotchas


### PR DESCRIPTION
## Summary

Adds the TMLR 2025 StructEval paper to Articles. StructEval directly evaluates LLM generation and conversion of YAML using syntax and structural checks as part of a broader 18-format benchmark. The entry links the primary paper and official implementation.

## Validation

- Confirmed there is no existing StructEval entry or submission.
- Followed the existing article title and description format.
- Verified the official paper and code links.
- Ran `git diff --check`.

Disclosure: I am a maintainer of StructEval. This submission was prepared with assistance from OpenAI Codex.