### PR TITLE
Add Nutilz JSON Schema Generator to Tools & Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ is the same as:
 - [**Yamlinc**](https://github.com/javanile/yamlinc) - compose multiple files using $include tag / compiler
 - [**YAML Validator**](https://yamlvalidator.dev), [(chrome extension)](https://chromewebstore.google.com/detail/yaml-validator/gjgbohnlhijomhfiflapnlnmcpckgigg) - online YAML validator, formatter and viewer with JSON Schema support (Kubernetes, Docker Compose, GitHub Actions, and more)
 - [**dasel ("data-selector")**](https://github.com/tomwright/dasel) - Query and update data structures using selectors from the command line. Comparable to [jq](https://github.com/stedlan/jq) / [yq](https://github.com/kislyuk/yq) but supports JSON, YAML, TOML and XML with zero runtime dependencies.
+- [**JSON Schema Generator @ Nutilz**](https://nutilz.com/json-schema-generator) - infers a JSON Schema from sample JSON data (useful for validating YAML-derived configs like Kubernetes manifests or GitHub Actions), fully client-side, no signup
 
 
 ## No Body Wants To Write YAML 


### PR DESCRIPTION
Adds Nutilz's free JSON Schema Generator (https://nutilz.com/json-schema-generator) to the Tools & Services section.

It infers Draft-07 / 2020-12 JSON Schemas from sample JSON data and validates JSON against a schema, entirely client-side (nothing uploaded). Relevant here since JSON Schema is commonly used to validate YAML-derived configs (Kubernetes manifests, GitHub Actions, etc.) — the existing YAML Validator entry above already references JSON Schema support for the same use case.