### PR TITLE
Add yaml-drift to Tools & Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ is the same as:
 - [**Yamlinc**](https://github.com/javanile/yamlinc) - compose multiple files using $include tag / compiler
 - [**YAML Validator**](https://yamlvalidator.dev), [(chrome extension)](https://chromewebstore.google.com/detail/yaml-validator/gjgbohnlhijomhfiflapnlnmcpckgigg) - online YAML validator, formatter and viewer with JSON Schema support (Kubernetes, Docker Compose, GitHub Actions, and more)
 - [**dasel ("data-selector")**](https://github.com/tomwright/dasel) - Query and update data structures using selectors from the command line. Comparable to [jq](https://github.com/stedlan/jq) / [yq](https://github.com/kislyuk/yq) but supports JSON, YAML, TOML and XML with zero runtime dependencies.
-
+- [**yaml-drift**](https://github.com/tamerkalla/yaml-drift) - convert YAML to JSON and get a report of every value whose meaning changed - precision, non-finite numbers, coerced keys, dropped tags, and scalars that YAML 1.1 reads differently
 
 ## No Body Wants To Write YAML 
 


### PR DESCRIPTION
Adds one entry to **Tools & Services**, beside the existing YAML ↔ JSON converter.

The gap it fills: YAML has unbounded integers, `.inf`/`.nan`, non-string mapping keys, anchors, merge keys and tags, and JSON has none of them. Converters coerce whatever does not fit and stay silent, because from their point of view nothing went wrong. On top of that, YAML 1.1 and YAML 1.2 resolve unquoted scalars differently, so `country: NO` is the string `"NO"` to a JavaScript reader and the boolean `false` to PyYAML, Psych and `yaml.v2`.

Measured on 40 short config-shaped documents: 34 come out of the conversion meaning something different, and the parser mentions 1 of them. This tool does the conversion and returns the list of what changed, with a JSON Pointer and line/column for each.

The entry follows the existing format in that section: bold link, dash, one-line description.
 